### PR TITLE
Make loop for `smallest_dimension_yet` inclusive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,7 @@ impl Grid {
         // Instead of numbers of columns, try to find the fewest number of *lines*
         // that the output will fit in.
         let mut smallest_dimensions_yet = None;
-        for num_lines in (1 .. theoretical_max_num_lines).rev() {
+        for num_lines in (1..=theoretical_max_num_lines).rev() {
 
             // The number of columns is the number of cells divided by the number
             // of lines, *rounded up*.


### PR DESCRIPTION
This is the change that we needed this whole fork for :)

For context see the original PR: https://github.com/ogham/rust-term-grid/pull/12

And the original issue: https://github.com/ogham/rust-term-grid/issues/11