### PR TITLE
More simplification (with a bonus performance boost)

### DIFF
--- a/examples/big.rs
+++ b/examples/big.rs
@@ -1,3 +1,6 @@
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
 extern crate term_grid;
 use term_grid::{Alignment, Cell, Direction, Filling, Grid, GridOptions};
 

--- a/examples/big.rs
+++ b/examples/big.rs
@@ -1,0 +1,25 @@
+extern crate term_grid;
+use term_grid::{Alignment, Cell, Direction, Filling, Grid, GridOptions};
+
+fn main() {
+    let mut grid = Grid::new(GridOptions {
+        direction: Direction::TopToBottom,
+        filling: Filling::Text(" | ".into()),
+    });
+
+    let mut n: u64 = 1234;
+    for _ in 0..50 {
+        for _ in 0..10000 {
+            let mut cell = Cell::from(format!("{}", n));
+            cell.alignment = Alignment::Right;
+            grid.add(cell);
+            n = n.overflowing_pow(2).0 % 100000000;
+        }
+
+        if let Some(grid_display) = grid.fit_into_width(80) {
+            println!("{}", grid_display);
+        } else {
+            println!("Couldn't fit grid into 80 columns!");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -469,11 +469,14 @@ impl fmt::Display for Display<'_> {
                             write!(f, "{}", cell.contents)?;
                         }
                         Alignment::Right => {
-                            let extra_spaces = self.dimensions.widths[x] - cell.width;
                             write!(
                                 f,
                                 "{}",
-                                pad_string(&cell.contents, extra_spaces, Alignment::Right)
+                                pad_string(
+                                    &cell.contents,
+                                    self.dimensions.widths[x],
+                                    Alignment::Right
+                                )
                             )?;
                         }
                     }
@@ -481,29 +484,38 @@ impl fmt::Display for Display<'_> {
                     assert!(self.dimensions.widths[x] >= cell.width);
                     match (&self.grid.options.filling, cell.alignment) {
                         (Filling::Spaces(n), Alignment::Left) => {
-                            let extra_spaces = self.dimensions.widths[x] - cell.width + n;
                             write!(
                                 f,
                                 "{}",
-                                pad_string(&cell.contents, extra_spaces, cell.alignment)
+                                pad_string(
+                                    &cell.contents,
+                                    self.dimensions.widths[x] + n,
+                                    cell.alignment
+                                )
                             )?;
                         }
                         (Filling::Spaces(n), Alignment::Right) => {
-                            let s = spaces(*n);
-                            let extra_spaces = self.dimensions.widths[x] - cell.width;
+                            let s = " ".repeat(*n);
                             write!(
                                 f,
                                 "{}{}",
-                                pad_string(&cell.contents, extra_spaces, cell.alignment),
+                                pad_string(
+                                    &cell.contents,
+                                    self.dimensions.widths[x],
+                                    cell.alignment
+                                ),
                                 s
                             )?;
                         }
                         (Filling::Text(ref t), _) => {
-                            let extra_spaces = self.dimensions.widths[x] - cell.width;
                             write!(
                                 f,
                                 "{}{}",
-                                pad_string(&cell.contents, extra_spaces, cell.alignment),
+                                pad_string(
+                                    &cell.contents,
+                                    self.dimensions.widths[x],
+                                    cell.alignment
+                                ),
                                 t
                             )?;
                         }
@@ -518,19 +530,10 @@ impl fmt::Display for Display<'_> {
     }
 }
 
-/// Pad a string with the given number of spaces.
-fn spaces(length: usize) -> String {
-    " ".repeat(length)
-}
-
-/// Pad a string with the given alignment and number of spaces.
-///
-/// This doesn’t take the width the string *should* be, rather the number
-/// of spaces to add.
-fn pad_string(string: &str, padding: usize, alignment: Alignment) -> String {
-    if alignment == Alignment::Left {
-        format!("{}{}", string, spaces(padding))
-    } else {
-        format!("{}{}", spaces(padding), string)
+/// Pad a string with the given alignment and size.
+fn pad_string(string: &str, size: usize, alignment: Alignment) -> String {
+    match alignment {
+        Alignment::Left => format!("{string:<size$}"),
+        Alignment::Right => format!("{string:>size$}"),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,12 +490,11 @@ impl fmt::Display for Display<'_> {
                         f.write_str(contents)?;
                     }
                 };
-                if last_in_row {
-                    f.write_str("\n")?;
-                } else {
+                if !last_in_row {
                     f.write_str(&separator)?;
                 }
             }
+            f.write_str("\n")?;
         }
 
         Ok(())


### PR DESCRIPTION
- Extract snippets like this into a `div_ceil` function:
```rust
let mut num_lines = self.cells.len() / num_columns;
if self.cells.len() % num_columns != 0 {
    num_lines += 1;
}
```
- Simplify the `Display` impl, by precalculating the separator and using the padding functionality of `format!`.
- Simplify `theoretical_max_num_lines` by using `enumerate` and only deal with the widths instead of the the whole `Cell`.
- Remove a clone in `width_dimensions`.
- Add an example that takes a few seconds for benchmarking.

Once I had the example, I benchmarked this against `main` and already got a >2.58x improvement!
```
Benchmark 1: target/bench/old
  Time (mean ± σ):      4.412 s ±  0.048 s    [User: 3.738 s, System: 0.670 s]
  Range (min … max):    4.354 s …  4.507 s    10 runs
 
Benchmark 2: target/bench/new
  Time (mean ± σ):      1.709 s ±  0.014 s    [User: 1.085 s, System: 0.624 s]
  Range (min … max):    1.694 s …  1.739 s    10 runs
 
Summary
  'target/bench/new' ran
    2.58 ± 0.03 times faster than 'target/bench/old'
```

EDIT: Got another performance boost from 2.1x to 2.5x faster