### PR TITLE
Allow grid to try to utilize maximum width it can

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,7 +409,7 @@ impl Grid {
                     adjusted_width = maximum_width - total_separator_width;
                     potential_dimensions = self.column_widths(num_lines, num_columns);
                 } else {
-                    break
+                    break;
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,17 +390,27 @@ impl Grid {
             // also serves as a speed-up.
             let total_separator_width = (num_columns - 1) * self.options.filling.width();
             if maximum_width < total_separator_width {
-                continue;
+                return None;
             }
 
             // Remove the separator width from the available space.
-            let adjusted_width = maximum_width - total_separator_width;
+            let mut adjusted_width = maximum_width - total_separator_width;
+            let mut potential_dimensions = self.column_widths(num_lines, num_columns);
 
-            let potential_dimensions = self.column_widths(num_lines, num_columns);
-            if potential_dimensions.widths.iter().sum::<Width>() < adjusted_width {
+            while potential_dimensions.widths.iter().sum::<Width>() < adjusted_width {
                 smallest_dimensions_yet = Some(potential_dimensions);
-            } else {
-                return smallest_dimensions_yet;
+
+                if self.cell_count % num_lines != 0 {
+                    num_columns += 1;
+                    let total_separator_width = (num_columns - 1) * self.options.filling.width();
+                    if maximum_width < total_separator_width {
+                        break;
+                    }
+                    adjusted_width = maximum_width - total_separator_width;
+                    potential_dimensions = self.column_widths(num_lines, num_columns);
+                } else {
+                    break
+                }
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,7 +414,7 @@ impl Grid {
             }
         }
 
-        None
+        smallest_dimensions_yet
     }
 }
 


### PR DESCRIPTION
Changes copied from: https://github.com/ogham/rust-term-grid/pull/14

These changes were initiated to fix the behavior of term-grid in [uutils](https://github.com/uutils/coreutils)'s `ls`

Things that were already taken care of by the time I opened this PR:
* Loop boundaries.

Things I've taken care of:
* Allowed grid to try to utilize the maximum width it can, optimizing for line-count.

Things I've *not* taken care of, yet:
* I didn't create a test to make sure this behavior does not regress.
* I didn't fix the [other bug](https://github.com/ogham/rust-term-grid/issues/13) where terminal color-codes ruin the width calculation.