### PR TITLE
API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ rust-version = "1.70"
 name = "term_grid"
 
 [dependencies]
-unicode-width = "0.1.11"
+textwrap = { version = "0.16.0", default-features = false, features = ["unicode-width"] }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![dependency status](https://deps.rs/repo/github/uutils/uutils-term-grid/status.svg)](https://deps.rs/repo/github/uutils/uutils-term-grid)
 [![CodeCov](https://codecov.io/gh/uutils/uutils-term-grid/branch/master/graph/badge.svg)](https://codecov.io/gh/uutils/uutils-term-grid)
 
-
 # uutils-term-grid
 
 This library arranges textual data in a grid format suitable for fixed-width fonts, using an algorithm to minimise the amount of space needed.
@@ -24,70 +23,69 @@ uutils_term_grid = "0.3"
 
 The Minimum Supported Rust Version is 1.70.
 
-
-## Usage
-
-This library arranges textual data in a grid format suitable for fixed-width fonts, using an algorithm to minimise the amount of space needed.
-For example:
+This library arranges textual data in a grid format suitable for
+fixed-width fonts, using an algorithm to minimise the amount of space
+needed. For example:
 
 ```rust
 use term_grid::{Grid, GridOptions, Direction, Filling, Cell};
 
-let mut grid = Grid::new(GridOptions {
-    filling:     Filling::Spaces(1),
-    direction:   Direction::LeftToRight,
-});
+let cells = vec![
+    "one", "two", "three", "four", "five", "six",
+    "seven", "eight", "nine", "ten", "eleven", "twelve"
+];
 
-for s in &["one", "two", "three", "four", "five", "six", "seven",
-           "eight", "nine", "ten", "eleven", "twelve"]
-{
-    grid.add(Cell::from(*s));
-}
+let grid = Grid::new(
+    cells,
+    GridOptions {
+        filling: Filling::Spaces(1),
+        direction: Direction::LeftToRight,
+        width: 24,
+    }
+);
 
-println!("{}", grid.fit_into_width(24).unwrap());
+println!("{grid}");
 ```
 
 Produces the following tabular result:
 
-```
+```text
 one  two three  four
 five six seven  eight
 nine ten eleven twelve
 ```
 
-
 ## Creating a grid
 
-To add data to a grid, first create a new `Grid` value, and then add cells to them with the `add` method.
+To add data to a grid, first create a new [`Grid`] value with a list of strings and a set of options.
 
-There are two options that must be specified in the `GridOptions` value that dictate how the grid is formatted:
+There are three options that must be specified in the [`GridOptions`] value
+that dictate how the grid is formatted:
 
-- `filling`: what to put in between two columns - either a number of spaces, or a text string;
-- `direction`, which specifies whether the cells should go along rows, or columns:
-    - `Direction::LeftToRight` starts them in the top left and moves *rightwards*, going to the start of a new row after reaching the final column;
-    - `Direction::TopToBottom` starts them in the top left and moves *downwards*, going to the top of a new column after reaching the final row.
-
-
-## Displaying a grid
-
-When display a grid, you can either specify the number of columns in advance, or try to find the maximum number of columns that can fit in an area of a given width.
-
-Splitting a series of cells into columns - or, in other words, starting a new row every *n* cells - is achieved with the `fit_into_columns` method on a `Grid` value.
-It takes as its argument the number of columns.
-
-Trying to fit as much data onto one screen as possible is the main use case for specifying a maximum width instead.
-This is achieved with the `fit_into_width` method.
-It takes the maximum allowed width, including separators, as its argument.
-However, it returns an *optional* `Display` value, depending on whether any of the cells actually had a width greater than the maximum width!
-If this is the case, your best bet is to just output the cells with one per line.
-
+- [`filling`](struct.GridOptions.html#structfield.direction): what to put in between two columns — either a number of
+  spaces, or a text string;
+- [`direction`](struct.GridOptions.html#structfield.direction): specifies whether the cells should go along
+  rows, or columns:
+  - `Direction::LeftToRight` starts them in the top left and
+    moves _rightwards_, going to the start of a new row after reaching the
+    final column;
+  - `Direction::TopToBottom` starts them in the top left and moves
+    _downwards_, going to the top of a new column after reaching the final
+    row.
+- [`width`](struct.GridOptions.html#structfield.direction): the width to fill the grid into. Usually, this should be the width
+  of the terminal.
 
 ## Cells and data
 
-Grids do not take `String`s or `&str`s - they take `Cells`.
+Grids to not take [`String`]s or `&str`s — they take [`Cell`] values.
 
-A **Cell** is a struct containing an individual cell’s contents, as a string, and its pre-computed length, which gets used when calculating a grid’s final dimensions.
-Usually, you want the *Unicode width* of the string to be used for this, so you can turn a `String` into a `Cell` with the `.into()` method.
+A [`Cell`] is a struct containing an individual cell’s contents, as a string,
+and its pre-computed length, which gets used when calculating a grid’s final
+dimensions. Usually, you want the _Unicode width_ of the string to be used for
+this, so you can turn a [`String`] into a [`Cell`] with the `.into()` function.
 
-However, you may also want to supply your own width: when you already know the width in advance, or when you want to change the measurement, such as skipping over terminal control characters.
-For cases like these, the fields on the `Cell` values are public, meaning you can construct your own instances as necessary.
+However, you may also want to supply your own width: when you already know the
+width in advance, or when you want to change the measurement, such as skipping
+over terminal control characters. For cases like these, the fields on the
+[`Cell`] values are public, meaning you can construct your own instances as
+necessary.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,28 @@ uutils_term_grid = "0.3"
 
 The Minimum Supported Rust Version is 1.70.
 
-This library arranges textual data in a grid format suitable for fixed-width
-fonts, using an algorithm to minimise the amount of space needed. For example:
+## Creating a grid
+
+To add data to a grid, first create a new [`Grid`] value with a list of strings
+and a set of options.
+
+There are three options that must be specified in the [`GridOptions`] value that
+dictate how the grid is formatted:
+
+- [`filling`][filling]: what to put in between two columns — either a number of
+  spaces, or a text string;
+- [`direction`][direction]: specifies whether the cells should go along rows, or
+  columns:
+  - [`Direction::LeftToRight`][LeftToRight] starts them in the top left and
+    moves _rightwards_, going to the start of a new row after reaching the final
+    column;
+  - [`Direction::TopToBottom`][TopToBottom] starts them in the top left and
+    moves _downwards_, going to the top of a new column after reaching the final
+    row.
+- [`width`][width]: the width to fill the grid into. Usually, this should be the
+  width of the terminal.
+
+In practice, creating a grid can be done as follows:
 
 ```rust
 use term_grid::{Grid, GridOptions, Direction, Filling};
@@ -68,27 +88,6 @@ one  two three  four
 five six seven  eight
 nine ten eleven twelve
 ```
-
-## Creating a grid
-
-To add data to a grid, first create a new [`Grid`] value with a list of strings
-and a set of options.
-
-There are three options that must be specified in the [`GridOptions`] value that
-dictate how the grid is formatted:
-
-- [`filling`][filling]: what to put in between two columns — either a number of
-  spaces, or a text string;
-- [`direction`][direction]: specifies whether the cells should go along rows, or
-  columns:
-  - [`Direction::LeftToRight`][LeftToRight] starts them in the top left and
-    moves _rightwards_, going to the start of a new row after reaching the final
-    column;
-  - [`Direction::TopToBottom`][TopToBottom] starts them in the top left and
-    moves _downwards_, going to the top of a new column after reaching the final
-    row.
-- [`width`][width]: the width to fill the grid into. Usually, this should be the
-  width of the terminal.
 
 [filling]: struct.GridOptions.html#structfield.filling
 [direction]: struct.GridOptions.html#structfield.direction

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ fixed-width fonts, using an algorithm to minimise the amount of space
 needed. For example:
 
 ```rust
-use term_grid::{Grid, GridOptions, Direction, Filling, Cell};
+use term_grid::{Grid, GridOptions, Direction, Filling};
 
 let cells = vec![
     "one", "two", "three", "four", "five", "six",

--- a/README.md
+++ b/README.md
@@ -4,17 +4,22 @@
 
 # uutils-term-grid
 
-This library arranges textual data in a grid format suitable for fixed-width fonts, using an algorithm to minimise the amount of space needed.
+This library arranges textual data in a grid format suitable for fixed-width
+fonts, using an algorithm to minimise the amount of space needed.
 
 ---
 
-This library is forked from the [`rust-term-grid`](https://github.com/ogham/rust-term-grid) library.
+This library is forked from the unmaintained
+[`rust-term-grid`](https://github.com/ogham/rust-term-grid) library. The core
+functionality has remained the same, with some additional bugfixes, performance
+improvements and a new API.
 
 ---
 
 # Installation
 
-This crate works with `cargo`. Add the following to your `Cargo.toml` dependencies section:
+This crate works with `cargo`. Add the following to your `Cargo.toml`
+dependencies section:
 
 ```toml
 [dependencies]
@@ -23,18 +28,26 @@ uutils_term_grid = "0.3"
 
 The Minimum Supported Rust Version is 1.70.
 
-This library arranges textual data in a grid format suitable for
-fixed-width fonts, using an algorithm to minimise the amount of space
-needed. For example:
+This library arranges textual data in a grid format suitable for fixed-width
+fonts, using an algorithm to minimise the amount of space needed. For example:
 
 ```rust
 use term_grid::{Grid, GridOptions, Direction, Filling};
 
+// Create a `Vec` of text to put in the grid
 let cells = vec![
     "one", "two", "three", "four", "five", "six",
     "seven", "eight", "nine", "ten", "eleven", "twelve"
 ];
 
+// Then create a `Grid` with those cells.
+// The grid requires several options:
+//  - The filling determines the string used as separator
+//    between the columns.
+//  - The direction specifies whether the layout should
+//    be done row-wise or column-wise.
+//  - The width is the maximum width that the grid might
+//    have.
 let grid = Grid::new(
     cells,
     GridOptions {
@@ -44,6 +57,7 @@ let grid = Grid::new(
     }
 );
 
+// A `Grid` implements `Display` and can be printed directly.
 println!("{grid}");
 ```
 
@@ -57,35 +71,39 @@ nine ten eleven twelve
 
 ## Creating a grid
 
-To add data to a grid, first create a new [`Grid`] value with a list of strings and a set of options.
+To add data to a grid, first create a new [`Grid`] value with a list of strings
+and a set of options.
 
-There are three options that must be specified in the [`GridOptions`] value
-that dictate how the grid is formatted:
+There are three options that must be specified in the [`GridOptions`] value that
+dictate how the grid is formatted:
 
-- [`filling`](struct.GridOptions.html#structfield.direction): what to put in between two columns — either a number of
+- [`filling`][filling]: what to put in between two columns — either a number of
   spaces, or a text string;
-- [`direction`](struct.GridOptions.html#structfield.direction): specifies whether the cells should go along
-  rows, or columns:
-  - `Direction::LeftToRight` starts them in the top left and
-    moves _rightwards_, going to the start of a new row after reaching the
-    final column;
-  - `Direction::TopToBottom` starts them in the top left and moves
-    _downwards_, going to the top of a new column after reaching the final
+- [`direction`][direction]: specifies whether the cells should go along rows, or
+  columns:
+  - [`Direction::LeftToRight`][LeftToRight] starts them in the top left and
+    moves _rightwards_, going to the start of a new row after reaching the final
+    column;
+  - [`Direction::TopToBottom`][TopToBottom] starts them in the top left and
+    moves _downwards_, going to the top of a new column after reaching the final
     row.
-- [`width`](struct.GridOptions.html#structfield.direction): the width to fill the grid into. Usually, this should be the width
-  of the terminal.
+- [`width`][width]: the width to fill the grid into. Usually, this should be the
+  width of the terminal.
 
-## Cells and data
+[filling]: struct.GridOptions.html#structfield.filling
+[direction]: struct.GridOptions.html#structfield.direction
+[width]: struct.GridOptions.html#structfield.width
+[LeftToRight]: enum.Direction.html#variant.LeftToRight
+[TopToBottom]: enum.Direction.html#variant.TopToBottom
 
-Grids to not take [`String`]s or `&str`s — they take [`Cell`] values.
+## Width of grid cells
 
-A [`Cell`] is a struct containing an individual cell’s contents, as a string,
-and its pre-computed length, which gets used when calculating a grid’s final
-dimensions. Usually, you want the _Unicode width_ of the string to be used for
-this, so you can turn a [`String`] into a [`Cell`] with the `.into()` function.
+This library calculates the width of strings as displayed in the terminal using
+the [`textwrap`][textwrap] library (with the [`display_width`][display_width] function).
+This takes into account the width of characters and ignores ANSI codes.
 
-However, you may also want to supply your own width: when you already know the
-width in advance, or when you want to change the measurement, such as skipping
-over terminal control characters. For cases like these, the fields on the
-[`Cell`] values are public, meaning you can construct your own instances as
-necessary.
+The width calculation is currently not configurable. If you have a use-case for
+which this calculation is wrong, please open an issue.
+
+[textwrap]: https://docs.rs/textwrap/latest/textwrap/index.html
+[display_width]: https://docs.rs/textwrap/latest/textwrap/core/fn.display_width.html

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,17 +12,20 @@ use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
 // 64 | 8192 | 1048576 | 134217728 | 17179869184 | 2199023255552 |
 
 fn main() {
-    let mut grid = Grid::new(GridOptions {
-        direction: Direction::TopToBottom,
-        filling: Filling::Text(" | ".into()),
-    });
+    let cells: Vec<_> = (0..48)
+        .map(|i| Cell::from(2_isize.pow(i).to_string()))
+        .collect();
 
-    for i in 0..48 {
-        let cell = Cell::from(2_isize.pow(i).to_string());
-        grid.add(cell)
-    }
+    let grid = Grid::new(
+        cells,
+        GridOptions {
+            direction: Direction::TopToBottom,
+            filling: Filling::Text(" | ".into()),
+            width: 80,
+        },
+    );
 
-    if let Some(grid_display) = grid.fit_into_width(80) {
+    if let Some(grid_display) = grid {
         println!("{}", grid_display);
     } else {
         println!("Couldn't fit grid into 80 columns!");

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -25,9 +25,5 @@ fn main() {
         },
     );
 
-    if let Some(grid_display) = grid {
-        println!("{}", grid_display);
-    } else {
-        println!("Couldn't fit grid into 80 columns!");
-    }
+    println!("{}", grid);
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,6 @@
-extern crate term_grid;
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
 use term_grid::{Direction, Filling, Grid, GridOptions};
 
 // This produces:

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,5 @@
 extern crate term_grid;
-use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
+use term_grid::{Direction, Filling, Grid, GridOptions};
 
 // This produces:
 //
@@ -12,9 +12,7 @@ use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
 // 64 | 8192 | 1048576 | 134217728 | 17179869184 | 2199023255552 |
 
 fn main() {
-    let cells: Vec<_> = (0..48)
-        .map(|i| Cell::from(2_isize.pow(i).to_string()))
-        .collect();
+    let cells: Vec<_> = (0..48).map(|i| 2_isize.pow(i).to_string()).collect();
 
     let grid = Grid::new(
         cells,

--- a/examples/big.rs
+++ b/examples/big.rs
@@ -1,7 +1,6 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-extern crate term_grid;
 use term_grid::{Direction, Filling, Grid, GridOptions};
 
 fn main() {

--- a/examples/big.rs
+++ b/examples/big.rs
@@ -5,19 +5,24 @@ extern crate term_grid;
 use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
 
 fn main() {
-    let mut grid = Grid::new(GridOptions {
-        direction: Direction::TopToBottom,
-        filling: Filling::Text(" | ".into()),
-    });
-
     let mut n: u64 = 1234;
     for _ in 0..50 {
+        let mut cells = Vec::new();
         for _ in 0..10000 {
-            grid.add(Cell::from(n.to_string()));
+            cells.push(Cell::from(n.to_string()));
             n = n.overflowing_pow(2).0 % 100000000;
         }
 
-        if let Some(grid_display) = grid.fit_into_width(80) {
+        let grid = Grid::new(
+            cells,
+            GridOptions {
+                direction: Direction::TopToBottom,
+                filling: Filling::Text(" | ".into()),
+                width: 80,
+            },
+        );
+
+        if let Some(grid_display) = grid {
             println!("{}", grid_display);
         } else {
             println!("Couldn't fit grid into 80 columns!");

--- a/examples/big.rs
+++ b/examples/big.rs
@@ -2,14 +2,14 @@
 // file that was distributed with this source code.
 
 extern crate term_grid;
-use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
+use term_grid::{Direction, Filling, Grid, GridOptions};
 
 fn main() {
     let mut n: u64 = 1234;
     for _ in 0..50 {
         let mut cells = Vec::new();
         for _ in 0..10000 {
-            cells.push(Cell::from(n.to_string()));
+            cells.push(n.to_string());
             n = n.overflowing_pow(2).0 % 100000000;
         }
 
@@ -22,6 +22,6 @@ fn main() {
             },
         );
 
-        println!("{}", grid);
+        println!("{grid}");
     }
 }

--- a/examples/big.rs
+++ b/examples/big.rs
@@ -22,10 +22,6 @@ fn main() {
             },
         );
 
-        if let Some(grid_display) = grid {
-            println!("{}", grid_display);
-        } else {
-            println!("Couldn't fit grid into 80 columns!");
-        }
+        println!("{}", grid);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ impl<T: AsRef<str>> Grid<T> {
 
         grid.dimensions = grid.width_dimensions(width).unwrap_or(Dimensions {
             num_lines: grid.cells.len(),
-            widths: grid.widths.clone(),
+            widths: vec![widest_cell_width],
         });
 
         grid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!     }
 //! );
 //!
-//! println!("{}", grid.unwrap());
+//! println!("{grid}");
 //! ```
 //!
 //! Produces the following tabular result:
@@ -192,7 +192,7 @@ pub struct Grid {
 
 impl Grid {
     /// Creates a new grid view with the given options.
-    pub fn new<T: Into<Cell>>(cells: Vec<T>, options: GridOptions) -> Option<Self> {
+    pub fn new<T: Into<Cell>>(cells: Vec<T>, options: GridOptions) -> Self {
         let cells: Vec<Cell> = cells.into_iter().map(Into::into).collect();
         let widest_cell_length = cells.iter().map(|c| c.width).max().unwrap_or(0);
         let width = options.width;
@@ -207,8 +207,12 @@ impl Grid {
             },
         };
 
-        grid.dimensions = grid.width_dimensions(width)?;
-        Some(grid)
+        grid.dimensions = grid.width_dimensions(width).unwrap_or(Dimensions {
+            num_lines: grid.cells.len(),
+            widths: grid.cells.iter().map(|c| c.width).collect(),
+        });
+
+        grid
     }
 
     fn column_widths(&self, num_lines: usize, num_columns: usize) -> Dimensions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
 #![warn(future_incompatible)]
 #![warn(missing_copy_implementations)]
 #![warn(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub struct Cell {
     pub contents: String,
 
     /// The pre-computed length of the string.
-    pub width: Width,
+    pub width: usize,
 }
 
 impl From<String> for Cell {
@@ -121,15 +121,12 @@ pub enum Direction {
     TopToBottom,
 }
 
-/// The width of a cell, in columns.
-pub type Width = usize;
-
 /// The text to put in between each pair of columns.
 /// This does not include any spaces used when aligning cells.
 #[derive(PartialEq, Eq, Debug)]
 pub enum Filling {
     /// A certain number of spaces should be used as the separator.
-    Spaces(Width),
+    Spaces(usize),
 
     /// An arbitrary string.
     /// `"|"` is a common choice.
@@ -137,7 +134,7 @@ pub enum Filling {
 }
 
 impl Filling {
-    fn width(&self) -> Width {
+    fn width(&self) -> usize {
         match *self {
             Filling::Spaces(w) => w,
             Filling::Text(ref t) => UnicodeWidthStr::width(&t[..]),
@@ -163,19 +160,19 @@ pub struct GridOptions {
 #[derive(PartialEq, Eq, Debug)]
 struct Dimensions {
     /// The number of lines in the grid.
-    num_lines: Width,
+    num_lines: usize,
 
     /// The width of each column in the grid. The length of this vector serves
     /// as the number of columns.
-    widths: Vec<Width>,
+    widths: Vec<usize>,
 }
 
 impl Dimensions {
-    fn total_width(&self, separator_width: Width) -> Width {
+    fn total_width(&self, separator_width: usize) -> usize {
         if self.widths.is_empty() {
             0
         } else {
-            let values = self.widths.iter().sum::<Width>();
+            let values = self.widths.iter().sum::<usize>();
             let separators = separator_width * (self.widths.len() - 1);
             values + separators
         }
@@ -189,7 +186,7 @@ impl Dimensions {
 pub struct Grid {
     options: GridOptions,
     cells: Vec<Cell>,
-    widest_cell_length: Width,
+    widest_cell_length: usize,
     dimensions: Dimensions,
 }
 
@@ -251,7 +248,7 @@ impl Grid {
         1
     }
 
-    fn width_dimensions(&self, maximum_width: Width) -> Option<Dimensions> {
+    fn width_dimensions(&self, maximum_width: usize) -> Option<Dimensions> {
         if self.widest_cell_length > maximum_width {
             // Largest cell is wider than maximum width; it is impossible to fit.
             return None;
@@ -304,7 +301,7 @@ impl Grid {
             let adjusted_width = maximum_width - total_separator_width;
 
             let potential_dimensions = self.column_widths(num_lines, num_columns);
-            if potential_dimensions.widths.iter().sum::<Width>() < adjusted_width {
+            if potential_dimensions.widths.iter().sum::<usize>() < adjusted_width {
                 smallest_dimensions_yet = Some(potential_dimensions);
             } else {
                 return smallest_dimensions_yet;
@@ -318,7 +315,7 @@ impl Grid {
 impl Grid {
     /// Returns how many columns this display takes up, based on the separator
     /// width and the number and width of the columns.
-    pub fn width(&self) -> Width {
+    pub fn width(&self) -> usize {
         self.dimensions.total_width(self.options.filling.width())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,7 +312,7 @@ impl<T: AsRef<str>> fmt::Display for Grid<T> {
 
 // Adapted from the unstable API:
 // https://doc.rust-lang.org/std/primitive.usize.html#method.div_ceil
-// Can be removed on MSRV 1.70.
+// Can be removed on MSRV 1.73.
 /// Division with upward rounding
 pub const fn div_ceil(lhs: usize, rhs: usize) -> usize {
     let d = lhs / rhs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@ pub struct Grid<T: AsRef<str>> {
     dimensions: Dimensions,
 }
 
-// Public methods
 impl<T: AsRef<str>> Grid<T> {
     /// Creates a new grid view with the given cells and options
     pub fn new(cells: Vec<T>, options: GridOptions) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ impl Dimensions {
 pub struct Grid {
     options: GridOptions,
     cells: Vec<Cell>,
-    widest_cell_length: usize,
+    widest_cell_width: usize,
     dimensions: Dimensions,
 }
 
@@ -134,13 +134,13 @@ impl Grid {
     /// Creates a new grid view with the given cells and options
     pub fn new<T: Into<Cell>>(cells: Vec<T>, options: GridOptions) -> Self {
         let cells: Vec<Cell> = cells.into_iter().map(Into::into).collect();
-        let widest_cell_length = cells.iter().map(|c| c.width).max().unwrap_or(0);
+        let widest_cell_width = cells.iter().map(|c| c.width).max().unwrap_or(0);
         let width = options.width;
 
         let mut grid = Self {
             options,
             cells,
-            widest_cell_length,
+            widest_cell_width,
             dimensions: Dimensions {
                 num_lines: 0,
                 widths: Vec::new(),
@@ -215,7 +215,7 @@ impl Grid {
     }
 
     fn width_dimensions(&self, maximum_width: usize) -> Option<Dimensions> {
-        if self.widest_cell_length > maximum_width {
+        if self.widest_cell_width > maximum_width {
             // Largest cell is wider than maximum width; it is impossible to fit.
             return None;
         }
@@ -293,7 +293,7 @@ impl fmt::Display for Grid {
         // We overestimate how many spaces we need, but this is not
         // part of the loop and it's therefore not super important to
         // get exactly right.
-        let padding = " ".repeat(self.widest_cell_length);
+        let padding = " ".repeat(self.widest_cell_width);
 
         for y in 0..self.dimensions.num_lines {
             for x in 0..self.dimensions.widths.len() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,167 +1,179 @@
-use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
+use term_grid::{Direction, Filling, Grid, GridOptions};
 
 #[test]
 fn no_items() {
-    let grid = Grid::new(GridOptions {
-        direction: Direction::TopToBottom,
-        filling: Filling::Spaces(2),
-    });
+    let grid = Grid::new(
+        Vec::<String>::new(),
+        GridOptions {
+            direction: Direction::TopToBottom,
+            filling: Filling::Spaces(2),
+            width: 40,
+        },
+    )
+    .unwrap();
 
-    let display = grid.fit_into_width(40).unwrap();
-    assert_eq!("", display.to_string());
+    assert_eq!("", grid.to_string());
 }
 
 #[test]
 fn one_item() {
-    let mut grid = Grid::new(GridOptions {
-        direction: Direction::TopToBottom,
-        filling: Filling::Spaces(2),
-    });
-
-    grid.add(Cell::from("1"));
-
-    let display = grid.fit_into_width(40).unwrap();
-    assert_eq!("1\n", display.to_string());
+    let grid = Grid::new(
+        vec!["1"],
+        GridOptions {
+            direction: Direction::TopToBottom,
+            filling: Filling::Spaces(2),
+            width: 40,
+        },
+    )
+    .unwrap();
+    assert_eq!("1\n", grid.to_string());
 }
 
 #[test]
 fn one_item_exact_width() {
-    let mut grid = Grid::new(GridOptions {
-        direction: Direction::TopToBottom,
-        filling: Filling::Spaces(2),
-    });
+    let grid = Grid::new(
+        vec!["1234567890"],
+        GridOptions {
+            direction: Direction::TopToBottom,
+            filling: Filling::Spaces(2),
+            width: 10,
+        },
+    )
+    .unwrap();
 
-    grid.add(Cell::from("1234567890"));
-
-    let display = grid.fit_into_width(10).unwrap();
-    assert_eq!("1234567890\n", display.to_string());
+    assert_eq!("1234567890\n", grid.to_string());
 }
 
 #[test]
 fn one_item_just_over() {
-    let mut grid = Grid::new(GridOptions {
-        direction: Direction::TopToBottom,
-        filling: Filling::Spaces(2),
-    });
+    let grid = Grid::new(
+        vec!["1234567890!"],
+        GridOptions {
+            direction: Direction::TopToBottom,
+            filling: Filling::Spaces(2),
+            width: 10,
+        },
+    );
 
-    grid.add(Cell::from("1234567890!"));
-
-    assert!(grid.fit_into_width(10).is_none());
+    assert!(grid.is_none());
 }
 
 #[test]
 fn two_small_items() {
-    let mut grid = Grid::new(GridOptions {
-        direction: Direction::TopToBottom,
-        filling: Filling::Spaces(2),
-    });
+    let grid = Grid::new(
+        vec!["1", "2"],
+        GridOptions {
+            direction: Direction::TopToBottom,
+            filling: Filling::Spaces(2),
+            width: 40,
+        },
+    )
+    .unwrap();
 
-    grid.add(Cell::from("1"));
-    grid.add(Cell::from("2"));
-
-    let display = grid.fit_into_width(40).unwrap();
-
-    assert_eq!(display.width(), 1 + 2 + 1);
-    assert_eq!("1  2\n", display.to_string());
+    assert_eq!(grid.width(), 1 + 2 + 1);
+    assert_eq!("1  2\n", grid.to_string());
 }
 
 #[test]
 fn two_medium_size_items() {
-    let mut grid = Grid::new(GridOptions {
-        direction: Direction::TopToBottom,
-        filling: Filling::Spaces(2),
-    });
+    let grid = Grid::new(
+        vec!["hello there", "how are you today?"],
+        GridOptions {
+            direction: Direction::TopToBottom,
+            filling: Filling::Spaces(2),
+            width: 40,
+        },
+    )
+    .unwrap();
 
-    grid.add(Cell::from("hello there"));
-    grid.add(Cell::from("how are you today?"));
-
-    let display = grid.fit_into_width(40).unwrap();
-
-    assert_eq!(display.width(), 11 + 2 + 18);
-    assert_eq!("hello there  how are you today?\n", display.to_string());
+    assert_eq!(grid.width(), 11 + 2 + 18);
+    assert_eq!("hello there  how are you today?\n", grid.to_string());
 }
 
 #[test]
 fn two_big_items() {
-    let mut grid = Grid::new(GridOptions {
-        direction: Direction::TopToBottom,
-        filling: Filling::Spaces(2),
-    });
+    let grid = Grid::new(
+        vec![
+            "nuihuneihsoenhisenouiuteinhdauisdonhuisudoiosadiuohnteihaosdinhteuieudi",
+            "oudisnuthasuouneohbueobaugceoduhbsauglcobeuhnaeouosbubaoecgueoubeohubeo",
+        ],
+        GridOptions {
+            direction: Direction::TopToBottom,
+            filling: Filling::Spaces(2),
+            width: 40,
+        },
+    );
 
-    grid.add(Cell::from(
-        "nuihuneihsoenhisenouiuteinhdauisdonhuisudoiosadiuohnteihaosdinhteuieudi",
-    ));
-    grid.add(Cell::from(
-        "oudisnuthasuouneohbueobaugceoduhbsauglcobeuhnaeouosbubaoecgueoubeohubeo",
-    ));
-
-    assert!(grid.fit_into_width(40).is_none());
+    assert!(grid.is_none());
 }
 
 #[test]
 fn that_example_from_earlier() {
-    let mut grid = Grid::new(GridOptions {
-        filling: Filling::Spaces(1),
-        direction: Direction::LeftToRight,
-    });
-
-    for s in &[
-        "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven",
-        "twelve",
-    ] {
-        grid.add(Cell::from(*s));
-    }
+    let grid = Grid::new(
+        vec![
+            "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+            "eleven", "twelve",
+        ],
+        GridOptions {
+            filling: Filling::Spaces(1),
+            direction: Direction::LeftToRight,
+            width: 24,
+        },
+    )
+    .unwrap();
 
     let bits = "one  two three  four\nfive six seven  eight\nnine ten eleven twelve\n";
-    assert_eq!(grid.fit_into_width(24).unwrap().to_string(), bits);
-    assert_eq!(grid.fit_into_width(24).unwrap().row_count(), 3);
+    assert_eq!(grid.to_string(), bits);
+    assert_eq!(grid.row_count(), 3);
 }
 
 #[test]
 fn number_grid_with_pipe() {
-    let mut grid = Grid::new(GridOptions {
-        filling: Filling::Text("|".into()),
-        direction: Direction::LeftToRight,
-    });
-
-    for s in &[
-        "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven",
-        "twelve",
-    ] {
-        grid.add(Cell::from(*s));
-    }
+    let grid = Grid::new(
+        vec![
+            "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+            "eleven", "twelve",
+        ],
+        GridOptions {
+            filling: Filling::Text("|".into()),
+            direction: Direction::LeftToRight,
+            width: 24,
+        },
+    )
+    .unwrap();
 
     let bits = "one |two|three |four\nfive|six|seven |eight\nnine|ten|eleven|twelve\n";
-    assert_eq!(grid.fit_into_width(24).unwrap().to_string(), bits);
-    assert_eq!(grid.fit_into_width(24).unwrap().row_count(), 3);
+    assert_eq!(grid.to_string(), bits);
+    assert_eq!(grid.row_count(), 3);
 }
 
 #[test]
 fn huge_separator() {
-    let mut grid = Grid::new(GridOptions {
-        filling: Filling::Spaces(100),
-        direction: Direction::LeftToRight,
-    });
-
-    grid.add("a".into());
-    grid.add("b".into());
-
-    assert!(grid.fit_into_width(99).is_none());
+    let grid = Grid::new(
+        vec!["a", "b"],
+        GridOptions {
+            filling: Filling::Spaces(100),
+            direction: Direction::LeftToRight,
+            width: 99,
+        },
+    );
+    assert!(grid.is_none());
 }
 
 #[test]
 fn huge_yet_unused_separator() {
-    let mut grid = Grid::new(GridOptions {
-        filling: Filling::Spaces(100),
-        direction: Direction::LeftToRight,
-    });
+    let grid = Grid::new(
+        vec!["abcd"],
+        GridOptions {
+            filling: Filling::Spaces(100),
+            direction: Direction::LeftToRight,
+            width: 99,
+        },
+    )
+    .unwrap();
 
-    grid.add("abcd".into());
-
-    let display = grid.fit_into_width(99).unwrap();
-
-    assert_eq!(display.width(), 4);
-    assert_eq!("abcd\n", display.to_string());
+    assert_eq!(grid.width(), 4);
+    assert_eq!("abcd\n", grid.to_string());
 }
 
 // Note: This behaviour is right or wrong depending on your terminal
@@ -169,17 +181,16 @@ fn huge_yet_unused_separator() {
 // behaviour, unless we explicitly want to do that.
 #[test]
 fn emoji() {
-    let mut grid = Grid::new(GridOptions {
-        direction: Direction::LeftToRight,
-        filling: Filling::Spaces(2),
-    });
-
-    for s in ["🦀", "hello", "👩‍🔬", "hello"] {
-        grid.add(s.into());
-    }
-
-    let display = grid.fit_into_width(12).unwrap();
-    assert_eq!("🦀    hello\n👩‍🔬  hello\n", display.to_string());
+    let grid = Grid::new(
+        vec!["🦀", "hello", "👩‍🔬", "hello"],
+        GridOptions {
+            direction: Direction::LeftToRight,
+            filling: Filling::Spaces(2),
+            width: 12,
+        },
+    )
+    .unwrap();
+    assert_eq!("🦀    hello\n👩‍🔬  hello\n", grid.to_string());
 }
 
 // These test are based on the tests in uutils ls, to ensure we won't break
@@ -203,83 +214,82 @@ mod uutils_ls {
                 "test-width-1\ntest-width-2\ntest-width-3\ntest-width-4\n",
             ),
         ] {
-            let mut grid = Grid::new(GridOptions {
-                direction: Direction::TopToBottom,
-                filling: Filling::Spaces(2),
-            });
-
-            for s in [
-                "test-width-1",
-                "test-width-2",
-                "test-width-3",
-                "test-width-4",
-            ] {
-                grid.add(s.into());
-            }
-
-            let display = grid.fit_into_width(width).unwrap();
-            assert_eq!(expected, display.to_string());
+            let grid = Grid::new(
+                vec![
+                    "test-width-1",
+                    "test-width-2",
+                    "test-width-3",
+                    "test-width-4",
+                ],
+                GridOptions {
+                    direction: Direction::TopToBottom,
+                    filling: Filling::Spaces(2),
+                    width,
+                },
+            )
+            .unwrap();
+            assert_eq!(expected, grid.to_string());
         }
     }
 
     #[test]
     fn across_width_30() {
-        let mut grid = Grid::new(GridOptions {
-            direction: Direction::LeftToRight,
-            filling: Filling::Spaces(2),
-        });
+        let grid = Grid::new(
+            vec![
+                "test-across1",
+                "test-across2",
+                "test-across3",
+                "test-across4",
+            ],
+            GridOptions {
+                direction: Direction::LeftToRight,
+                filling: Filling::Spaces(2),
+                width: 30,
+            },
+        )
+        .unwrap();
 
-        for s in [
-            "test-across1",
-            "test-across2",
-            "test-across3",
-            "test-across4",
-        ] {
-            grid.add(s.into());
-        }
-
-        let display = grid.fit_into_width(30).unwrap();
         assert_eq!(
             "test-across1  test-across2\ntest-across3  test-across4\n",
-            display.to_string()
+            grid.to_string()
         );
     }
 
     #[test]
     fn columns_width_30() {
-        let mut grid = Grid::new(GridOptions {
-            direction: Direction::TopToBottom,
-            filling: Filling::Spaces(2),
-        });
+        let grid = Grid::new(
+            vec![
+                "test-columns1",
+                "test-columns2",
+                "test-columns3",
+                "test-columns4",
+            ],
+            GridOptions {
+                direction: Direction::TopToBottom,
+                filling: Filling::Spaces(2),
+                width: 30,
+            },
+        )
+        .unwrap();
 
-        for s in [
-            "test-columns1",
-            "test-columns2",
-            "test-columns3",
-            "test-columns4",
-        ] {
-            grid.add(s.into());
-        }
-
-        let display = grid.fit_into_width(30).unwrap();
         assert_eq!(
             "test-columns1  test-columns3\ntest-columns2  test-columns4\n",
-            display.to_string()
+            grid.to_string()
         );
     }
 
     #[test]
     fn three_short_one_long() {
-        let mut grid = Grid::new(GridOptions {
-            direction: Direction::TopToBottom,
-            filling: Filling::Spaces(2),
-        });
+        let grid = Grid::new(
+            vec!["a", "b", "a-long-name", "z"],
+            GridOptions {
+                direction: Direction::TopToBottom,
+                filling: Filling::Spaces(2),
+                width: 15,
+            },
+        )
+        .unwrap();
 
-        for s in ["a", "b", "a-long-name", "z"] {
-            grid.add(s.into());
-        }
-
-        let display = grid.fit_into_width(15).unwrap();
-        assert_eq!("a  a-long-name\nb  z\n", display.to_string());
+        assert_eq!("a  a-long-name\nb  z\n", grid.to_string());
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,8 +9,7 @@ fn no_items() {
             filling: Filling::Spaces(2),
             width: 40,
         },
-    )
-    .unwrap();
+    );
 
     assert_eq!("", grid.to_string());
 }
@@ -24,8 +23,7 @@ fn one_item() {
             filling: Filling::Spaces(2),
             width: 40,
         },
-    )
-    .unwrap();
+    );
     assert_eq!("1\n", grid.to_string());
 }
 
@@ -38,8 +36,7 @@ fn one_item_exact_width() {
             filling: Filling::Spaces(2),
             width: 10,
         },
-    )
-    .unwrap();
+    );
 
     assert_eq!("1234567890\n", grid.to_string());
 }
@@ -55,7 +52,7 @@ fn one_item_just_over() {
         },
     );
 
-    assert!(grid.is_none());
+    assert_eq!(grid.row_count(), 1);
 }
 
 #[test]
@@ -67,8 +64,7 @@ fn two_small_items() {
             filling: Filling::Spaces(2),
             width: 40,
         },
-    )
-    .unwrap();
+    );
 
     assert_eq!(grid.width(), 1 + 2 + 1);
     assert_eq!("1  2\n", grid.to_string());
@@ -83,8 +79,7 @@ fn two_medium_size_items() {
             filling: Filling::Spaces(2),
             width: 40,
         },
-    )
-    .unwrap();
+    );
 
     assert_eq!(grid.width(), 11 + 2 + 18);
     assert_eq!("hello there  how are you today?\n", grid.to_string());
@@ -104,7 +99,7 @@ fn two_big_items() {
         },
     );
 
-    assert!(grid.is_none());
+    assert_eq!(grid.row_count(), 2);
 }
 
 #[test]
@@ -119,8 +114,7 @@ fn that_example_from_earlier() {
             direction: Direction::LeftToRight,
             width: 24,
         },
-    )
-    .unwrap();
+    );
 
     let bits = "one  two three  four\nfive six seven  eight\nnine ten eleven twelve\n";
     assert_eq!(grid.to_string(), bits);
@@ -139,8 +133,7 @@ fn number_grid_with_pipe() {
             direction: Direction::LeftToRight,
             width: 24,
         },
-    )
-    .unwrap();
+    );
 
     let bits = "one |two|three |four\nfive|six|seven |eight\nnine|ten|eleven|twelve\n";
     assert_eq!(grid.to_string(), bits);
@@ -157,7 +150,7 @@ fn huge_separator() {
             width: 99,
         },
     );
-    assert!(grid.is_none());
+    assert_eq!(grid.row_count(), 2);
 }
 
 #[test]
@@ -169,8 +162,7 @@ fn huge_yet_unused_separator() {
             direction: Direction::LeftToRight,
             width: 99,
         },
-    )
-    .unwrap();
+    );
 
     assert_eq!(grid.width(), 4);
     assert_eq!("abcd\n", grid.to_string());
@@ -188,8 +180,7 @@ fn emoji() {
             filling: Filling::Spaces(2),
             width: 12,
         },
-    )
-    .unwrap();
+    );
     assert_eq!("🦀    hello\n👩‍🔬  hello\n", grid.to_string());
 }
 
@@ -226,8 +217,7 @@ mod uutils_ls {
                     filling: Filling::Spaces(2),
                     width,
                 },
-            )
-            .unwrap();
+            );
             assert_eq!(expected, grid.to_string());
         }
     }
@@ -246,8 +236,7 @@ mod uutils_ls {
                 filling: Filling::Spaces(2),
                 width: 30,
             },
-        )
-        .unwrap();
+        );
 
         assert_eq!(
             "test-across1  test-across2\ntest-across3  test-across4\n",
@@ -269,8 +258,7 @@ mod uutils_ls {
                 filling: Filling::Spaces(2),
                 width: 30,
             },
-        )
-        .unwrap();
+        );
 
         assert_eq!(
             "test-columns1  test-columns3\ntest-columns2  test-columns4\n",
@@ -287,8 +275,7 @@ mod uutils_ls {
                 filling: Filling::Spaces(2),
                 width: 15,
             },
-        )
-        .unwrap();
+        );
 
         assert_eq!("a  a-long-name\nb  z\n", grid.to_string());
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,6 @@
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
 use term_grid::{Direction, Filling, Grid, GridOptions};
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,8 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+// spell-checker:ignore underflowed
+
 use term_grid::{Direction, Filling, Grid, GridOptions};
 
 #[test]
@@ -185,6 +187,24 @@ fn emoji() {
         },
     );
     assert_eq!("🦀    hello\n👩‍🔬  hello\n", grid.to_string());
+}
+
+// This test once underflowed, which should never happen. The test is just
+// checking that we do not get a panic.
+#[test]
+fn possible_underflow() {
+    let cells: Vec<_> = (0..48).map(|i| 2_isize.pow(i).to_string()).collect();
+
+    let grid = Grid::new(
+        cells,
+        GridOptions {
+            direction: Direction::TopToBottom,
+            filling: Filling::Text(" | ".into()),
+            width: 15,
+        },
+    );
+
+    println!("{}", grid);
 }
 
 // These test are based on the tests in uutils ls, to ensure we won't break


### PR DESCRIPTION
Closes https://github.com/uutils/uutils-term-grid/issues/25
Closes https://github.com/uutils/uutils-term-grid/issues/26

Ultimately, I want to refine the API even more, but I think this is a pretty good step in the right direction. Note how all the tests and examples are now more declarative. The `grid` values never have to be `mutable` anymore.

There is a bit of an ugly thing, which is that `dimensions` is set to some unused dummy value before it is modified. We could refactor this internally with some `TempGrid` or something, but I wanted to focus this PR on the API.

Note that (as mentioned in #26) this PR removes the ability to use `fit_into_columns`.

cc @PThorpe92

The corresponding change in uutils `ls` would look like this: https://github.com/uutils/coreutils/pull/5485/files