### PR TITLE
fix: allow the screen to be filled exactly and fix off by one errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,9 +167,14 @@ impl<T: AsRef<str>> Grid<T> {
         widths.sort_unstable_by(|a, b| b.cmp(a));
 
         let mut col_total_width_so_far = 0;
-        for (i, width) in widths.iter().enumerate() {
-            if width + col_total_width_so_far <= maximum_width {
-                col_total_width_so_far += self.options.filling.width() + width;
+        for (i, &width) in widths.iter().enumerate() {
+            let adjusted_width = if i == 0 {
+                width
+            } else {
+                width + self.options.filling.width()
+            };
+            if col_total_width_so_far + adjusted_width <= maximum_width {
+                col_total_width_so_far += adjusted_width;
             } else {
                 return div_ceil(self.cells.len(), i);
             }
@@ -234,14 +239,14 @@ impl<T: AsRef<str>> Grid<T> {
             let adjusted_width = maximum_width - total_separator_width;
 
             let potential_dimensions = self.column_widths(num_lines, num_columns);
-            if potential_dimensions.widths.iter().sum::<usize>() < adjusted_width {
+            if potential_dimensions.widths.iter().sum::<usize>() <= adjusted_width {
                 smallest_dimensions_yet = Some(potential_dimensions);
             } else {
-                return smallest_dimensions_yet;
+                break;
             }
         }
 
-        None
+        smallest_dimensions_yet
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -207,6 +207,37 @@ fn possible_underflow() {
     println!("{}", grid);
 }
 
+#[test]
+fn exact_fit() {
+    let grid = Grid::new(
+        vec!["a", "b", "c", "d"],
+        GridOptions {
+            direction: Direction::TopToBottom,
+            filling: Filling::Spaces(2),
+            width: 4,
+        },
+    );
+
+    assert_eq!(grid.row_count(), 2);
+}
+
+// This is a reproduction of https://github.com/eza-community/eza/issues/845
+#[test]
+fn eza_many_folders() {
+    let cells: Vec<_> = (100000i32..=100401).map(|i| i.to_string()).collect();
+
+    let grid = Grid::new(
+        cells,
+        GridOptions {
+            direction: Direction::TopToBottom,
+            filling: Filling::Spaces(2),
+            width: 166,
+        },
+    );
+
+    assert_eq!(grid.row_count(), 20);
+}
+
 // These test are based on the tests in uutils ls, to ensure we won't break
 // it while editing this library.
 mod uutils_ls {


### PR DESCRIPTION
A fix for https://github.com/eza-community/eza/issues/799 and another case I found along the way.

This change does not seem to break anything in uutils.