### PR TITLE
clippy: fix warnings from `uninlined_format_args`

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -25,5 +25,5 @@ fn main() {
         },
     );
 
-    println!("{}", grid);
+    println!("{grid}");
 }

--- a/examples/tabs.rs
+++ b/examples/tabs.rs
@@ -28,5 +28,5 @@ fn main() {
         },
     );
 
-    println!("{}", grid);
+    println!("{grid}");
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -204,7 +204,7 @@ fn possible_underflow() {
         },
     );
 
-    println!("{}", grid);
+    println!("{grid}");
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes warnings from the [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) lint.