### PR TITLE
fix off-by-one in column-search loop and add regression test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ impl<T: AsRef<str>> Grid<T> {
         }
 
         // Try to increase number of columns, to see if new dimension can still fit.
-        for num_columns in min_columns + 1..self.cells.len() {
+        for num_columns in min_columns + 1..=self.cells.len() {
             let Some(adjusted_width) = self
                 .options
                 .width

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -402,6 +402,30 @@ fn weird_column_edge_case() {
     assert_eq!(grid.to_string(), expected);
 }
 
+// Regression test for the off-by-one in the column-search loop: when cells
+// have varying widths, all cells can sometimes fit on a single row even though
+// the worst-case (widest cell) estimate says they can't. The loop must try
+// num_columns == cells.len() (..= rather than ..).
+//
+// Setup: cells ["aaa","b","c","d"], separator 1, width 9.
+//   widest_column = 3+1 = 4  →  min_columns = (9+1)/4 = 2
+//   Loop with bug  (2+1 .. 4): tries only 3 cols → 2 rows
+//   Loop with fix  (2+1 ..= 4): also tries 4 cols → sum 3+1+1+1=6 ≤ 9-3=6 → 1 row ✓
+#[test]
+fn all_cells_fit_on_one_row_when_widths_vary() {
+    let grid = Grid::new(
+        vec!["aaa", "b", "c", "d"],
+        GridOptions {
+            direction: Direction::LeftToRight,
+            filling: Filling::Spaces(1),
+            width: 9,
+        },
+    );
+
+    assert_eq!(grid.row_count(), 1);
+    assert_eq!(grid.to_string(), "aaa b c d\n");
+}
+
 // These test are based on the tests in uutils ls, to ensure we won't break
 // it while editing this library.
 mod uutils_ls {


### PR DESCRIPTION
The loop in `width_dimensions` used an exclusive upper bound (`..self.cells.len()`), so it never tried placing all cells on a single row. When cells have varying widths the single-row layout can fit even though the widest-cell estimate rules it out, producing a suboptimal result with more rows than necessary.

Change the range to `..=self.cells.len()` and add a regression test that catches the bug.

Disclaimer: This PR was done essentially 100% by a coding agent, with me only superficially verifying that its reasoning makes sense. However, I am convinced that the agent is correct.